### PR TITLE
Strike through reference to outdated official documentaion

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ The directories themselves serve as a table of contents.
 
 ## Official Documentation
 
-See the [official documentation](https://confluence.slac.stanford.edu/display/KIPAC/Computing) too!
+Coming soon! ~~See the [official documentation](https://confluence.slac.stanford.edu/display/KIPAC/Computing) too!~~
 
 ## Contributing
 


### PR DESCRIPTION
Struck through reference to outdated documentation and replaced with "coming soon".